### PR TITLE
Revert to RapidProTools v0.2.4

### DIFF
--- a/run_scripts/checkout_rapid_pro_tools.sh
+++ b/run_scripts/checkout_rapid_pro_tools.sh
@@ -12,7 +12,7 @@ fi
 RAPID_PRO_TOOLS_DIR="$1"
 
 RAPID_PRO_TOOLS_REPO="https://github.com/AfricasVoices/RapidProTools.git"
-TAG="48f7fb18f5e71c4ecc029cdf706bc19f2be1bd10"
+TAG="v0.2.4"
 
 mkdir -p "$RAPID_PRO_TOOLS_DIR"
 cd "$RAPID_PRO_TOOLS_DIR"


### PR DESCRIPTION
Now that the duplicate flows have been deleted from our TextIt instance, we no longer need to apply the temporary workaround we had.