### PR TITLE
Separate Show Remapping from Rapid Pro Key Name Remapping

### DIFF
--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -49,6 +49,13 @@ class TranslateRapidProKeys(object):
         "Rqa_S01E04 (Value) - csap_s01e04_activation": 4
     }
 
+    RAW_ID_MAP = {
+        1: "rqa_s01e01_raw",
+        2: "rqa_s01e02_raw",
+        3: "rqa_s01e03_raw",
+        4: "rqa_s01e04_raw"
+    }
+
     WEEK_3_TIME_KEY = "Rqa_S01E03 (Time) - csap_s01e03_activation"
     WEEK_3_VALUE_KEY = "Rqa_S01E03 (Value) - csap_s01e03_activation"
     WEEK_4_START = isoparse("2018-12-23T00:00:00+03:00")  # TODO: All other dates are strings, this should be too
@@ -150,22 +157,18 @@ class TranslateRapidProKeys(object):
             td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
     @classmethod
-    def translate_rapid_pro_keys(cls, user, data, coda_input_dir):
-        cls.set_show_ids(user, data, cls.SHOW_ID_MAP)
-        cls.remap_radio_show_weeks(user, data, coda_input_dir)
-        cls.remap_key_names(user, data, cls.RAPID_PRO_KEY_MAP)
-
-        raw_id_map = {
-            1: "rqa_s01e01_raw",
-            2: "rqa_s01e02_raw",
-            3: "rqa_s01e03_raw",
-            4: "rqa_s01e04_raw"
-        }
-
+    def set_rqa_raw_keys_from_show_ids(cls, user, data, raw_id_map):
         for td in data:
             for show_id, message_key in raw_id_map.items():
                 if "rqa_message" in td and td.get("show_id") == show_id:
                     td.append_data({message_key: td["rqa_message"]},
                                    Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+    @classmethod
+    def translate_rapid_pro_keys(cls, user, data, coda_input_dir):
+        cls.set_show_ids(user, data, cls.SHOW_ID_MAP)
+        cls.remap_radio_show_weeks(user, data, coda_input_dir)
+        cls.remap_key_names(user, data, cls.RAPID_PRO_KEY_MAP)
+        cls.set_rqa_raw_keys_from_show_ids(user, data, cls.RAW_ID_MAP)
 
         return data

--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -9,6 +9,7 @@ from project_redss.lib.redss_schemes import CodeSchemes
 
 
 class TranslateRapidProKeys(object):
+    # TODO: Move the constants in this file to configuration json
     RAPID_PRO_KEY_MAP = [
         # List of (new_key, old_key)
         ("uid", "avf_phone_id"),
@@ -98,6 +99,17 @@ class TranslateRapidProKeys(object):
 
     @classmethod
     def set_show_ids(cls, user, data, show_id_map):
+        """
+        Sets a show_id for each message, using the presence of Rapid Pro value keys to determine which show each message
+        belongs to.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to set the show ids of.
+        :type data: iterable of TracedData
+        :param show_id_map: Dictionary of Rapid Pro value key to show id.
+        :type show_id_map: dict of str -> int
+        """
         for td in data:
             show_dict = dict()
 
@@ -110,7 +122,22 @@ class TranslateRapidProKeys(object):
             td.append_data(show_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
     @classmethod
-    def remap_radio_show_weeks(cls, user, data, coda_input_dir):
+    def remap_radio_shows(cls, user, data, coda_input_dir):
+        """
+        Remaps radio shows which were in the wrong flow, and therefore have the wrong key/values set, to have the
+        key/values they would have had if they had been received by the correct flow.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to move the radio show messages in.
+        :type data: iterable of TracedData
+        :param coda_input_dir: Directory to read coded coda files from.
+        :type coda_input_dir: str
+        """
+        # TODO: Convert the show remapping code here into reusable functions for each case that they handle.
+        #       Note that ultimately we probably don't want to handle the 'WS' show remapping here,
+        #       because we get that for free when we implement 'WS' handling properly.
+
         # Build a map of raw week 3 messages to wrong scheme data
         message_to_s01e02_dict = cls._build_message_to_s01e02_dict(user, data, coda_input_dir)
 
@@ -145,6 +172,16 @@ class TranslateRapidProKeys(object):
 
     @classmethod
     def remap_key_names(cls, user, data, key_map):
+        """
+        Remaps key names.
+        
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to remap the key names of.
+        :type data: iterable of TracedData
+        :param key_map: Iterable of (new_key, old_key).
+        :type key_map: iterable of (str, str)
+        """
         for td in data:
             remapped = dict()
                
@@ -156,6 +193,21 @@ class TranslateRapidProKeys(object):
 
     @classmethod
     def set_rqa_raw_keys_from_show_ids(cls, user, data, raw_id_map):
+        """
+        Despite the earlier phases of this pipeline stage using a common 'rqa_message' field and then a 'show_id'
+        field to identify which radio show a message belonged to, the rest of the pipeline still uses the presence
+        of a raw field for each show to determine which show a message belongs to. This function translates from
+        the new 'show_id' method back to the old 'raw field presence` method.
+        
+        TODO: Update the rest of the pipeline to use show_ids, and/or perform remapping before combining the datasets.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to set raw radio show message fields for.
+        :type data: iterable of TracedData
+        :param raw_id_map: Dictionary of show id to the rqa message key to assign each td[rqa_message} to.
+        :type raw_id_map: dict of int -> str
+        """
         for td in data:
             for show_id, message_key in raw_id_map.items():
                 if "rqa_message" in td and td.get("show_id") == show_id:
@@ -164,9 +216,25 @@ class TranslateRapidProKeys(object):
 
     @classmethod
     def translate_rapid_pro_keys(cls, user, data, coda_input_dir):
+        """
+        Remaps the keys of rqa messages in the wrong flow into the correct one, and remaps all Rapid Pro keys to
+        more usable keys that can be used by the rest of the pipeline.
+        
+        TODO: Break this function such that the show remapping phase happens in one class, and the Rapid Pro remapping
+              in another?
+        """
+        # Set a show id field for each message, using the presence of Rapid Pro value keys in the TracedData.
+        # Show ids are necessary in order to be able to remap radio shows and key names separately (because data
+        # can't be 'deleted' from TracedData).
         cls.set_show_ids(user, data, cls.SHOW_ID_MAP)
-        cls.remap_radio_show_weeks(user, data, coda_input_dir)
+
+        # Move rqa messages which ended up in the wrong flow to the correct one.
+        cls.remap_radio_shows(user, data, coda_input_dir)
+
+        # Remap the keys used by Rapid Pro to more usable key names that will be used by the rest of the pipeline.
         cls.remap_key_names(user, data, cls.RAPID_PRO_KEY_MAP)
+
+        # Convert from the new show id format to the raw field format still used by the rest of the pipeline.
         cls.set_rqa_raw_keys_from_show_ids(user, data, cls.RAW_ID_MAP)
 
         return data

--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -1,8 +1,8 @@
-import time
 from os import path
 
 from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataCoda2IO
+from core_data_modules.util import TimeUtils
 from dateutil.parser import isoparse
 
 from project_redss.lib.redss_schemes import CodeSchemes
@@ -13,11 +13,6 @@ class TranslateRapidProKeys(object):
         # List of (new_key, old_key)
         ("uid", "avf_phone_id"),
 
-        ("rqa_s01e01_raw", "Rqa_S01E01 (Value) - csap_s01e01_activation"),
-        ("rqa_s01e02_raw", "Rqa_S01E02 (Value) - csap_s01e02_activation"),
-        # Not setting weeks 3 or 4 key here because they contain some messages from the other weeks.
-        # Special handling is performed in cls.translate_rapid_pro_keys()
-
         ("rqa_s01e01_run_id", "Rqa_S01E01 (Run ID) - csap_s01e01_activation"),
         ("rqa_s01e02_run_id", "Rqa_S01E02 (Run ID) - csap_s01e02_activation"),
         ("rqa_s01e03_run_id", "Rqa_S01E03 (Run ID) - csap_s01e03_activation"),
@@ -26,6 +21,7 @@ class TranslateRapidProKeys(object):
         ("sent_on", "Rqa_S01E01 (Time) - csap_s01e01_activation"),
         ("sent_on", "Rqa_S01E02 (Time) - csap_s01e02_activation"),
         ("sent_on", "Rqa_S01E03 (Time) - csap_s01e03_activation"),
+        ("sent_on", "Rqa_S01E04 (Time) - csap_s01e04_activation"),
 
         ("gender_raw", "Gender (Value) - csap_demog"),
         ("gender_time", "Gender (Time) - csap_demog"),
@@ -46,9 +42,16 @@ class TranslateRapidProKeys(object):
         ("involved_time", "Involved (Time) - csap_evaluation")
     ]
 
+    SHOW_ID_MAP = {
+        "Rqa_S01E01 (Value) - csap_s01e01_activation": 1,
+        "Rqa_S01E02 (Value) - csap_s01e02_activation": 2,
+        "Rqa_S01E03 (Value) - csap_s01e03_activation": 3,
+        "Rqa_S01E04 (Value) - csap_s01e04_activation": 4
+    }
+
     WEEK_3_TIME_KEY = "Rqa_S01E03 (Time) - csap_s01e03_activation"
     WEEK_3_VALUE_KEY = "Rqa_S01E03 (Value) - csap_s01e03_activation"
-    WEEK_4_START = isoparse("2018-12-23T00:00:00+03:00")
+    WEEK_4_START = isoparse("2018-12-23T00:00:00+03:00")  # TODO: All other dates are strings, this should be too
 
     WEEK_4_TIME_KEY = "Rqa_S01E04 (Time) - csap_s01e04_activation"
     WEEK_4_VALUE_KEY = "Rqa_S01E04 (Value) - csap_s01e04_activation"
@@ -62,7 +65,7 @@ class TranslateRapidProKeys(object):
     FRIDAY_CORRECTION_TIME = "2018-12-14T00:00:00+03:00"
 
     @classmethod
-    def build_message_to_s01e02_dict(cls, user, data, coda_input_dir):
+    def _build_message_to_s01e02_dict(cls, user, data, coda_input_dir):
         # Duplicate the input list because reading the file requires appending data to the TracedData,
         # and we don't actually want to modify the input at this stage of the pipeline.
         data = [td.copy() for td in data]
@@ -87,59 +90,82 @@ class TranslateRapidProKeys(object):
         return message_to_ws_dict
 
     @classmethod
-    def translate_rapid_pro_keys(cls, user, data, coda_input_dir):
-        """
-        Uses the cls.RAPID_PRO_KEY_MAP to rename the keys exported by Rapid Pro to keys which are easier to work
-        with in the pipeline. 
-        
-        Also performs several project-specific redirects of radio show question messages which went into the wrong
-        activation flow when running the project. These redirects are described in the comments below. These
-        redirects are performed here so that the rest of the pipeline can be given a dataset where it looked like
-        nothing went wrong, which means operational corrections shouldn't be needed so much elsewhere.
-        """
-        
+    def set_show_ids(cls, user, data, show_id_map):
+        for td in data:
+            show_dict = dict()
+
+            for message_key, show_id in show_id_map.items():
+                if message_key in td:
+                    assert "rqa_message" not in show_dict
+                    show_dict["rqa_message"] = td[message_key]
+                    show_dict["show_id"] = show_id
+
+            td.append_data(show_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+    @classmethod
+    def remap_radio_show_weeks(cls, user, data, coda_input_dir):
         # Build a map of raw week 3 messages to wrong scheme data
-        message_to_s01e02_dict = cls.build_message_to_s01e02_dict(user, data, coda_input_dir)
-        
-        # Do the actual key mapping
+        message_to_s01e02_dict = cls._build_message_to_s01e02_dict(user, data, coda_input_dir)
+
         for td in data:
             mapped_dict = dict()
-            
+
             if cls.WEEK_3_TIME_KEY in td:
                 # Redirect any week 3 messages coded as s01e02 in the WS - Correct Dataset scheme to week 2
-                if message_to_s01e02_dict.get(td[cls.WEEK_3_VALUE_KEY], False):
-                    mapped_dict["rqa_s01e02_raw"] = td[cls.WEEK_3_VALUE_KEY]
+                if message_to_s01e02_dict.get(td["rqa_message"], False):
+                    mapped_dict["show_id"] = 2
                 # Redirect any week 4 messages which were in the week 3 flow due to a late flow change-over.
                 elif isoparse(td[cls.WEEK_3_TIME_KEY]) > cls.WEEK_4_START:
-                    mapped_dict["rqa_s01e04_raw"] = td[cls.WEEK_3_VALUE_KEY]
-                else:
-                    mapped_dict["rqa_s01e03_raw"] = td[cls.WEEK_3_VALUE_KEY]
+                    mapped_dict["show_id"] = 4
 
             # Redirect any week 2 messages which were in the week 4 flow, due to undelivered messages being delivered
             # in two bursts after the end of the radio shows.
             if cls.WEEK_4_TIME_KEY in td:
                 if isoparse(cls.THURSDAY_BURST_START) <= isoparse(td[cls.WEEK_4_TIME_KEY]) < isoparse(cls.THURSDAY_BURST_END):
-                    mapped_dict["rqa_s01e02_raw"] = td[cls.WEEK_4_VALUE_KEY]
+                    mapped_dict["show_id"] = 2
                     mapped_dict["sent_on"] = cls.THURSDAY_CORRECTION_TIME
                 elif isoparse(cls.FRIDAY_BURST_START) <= isoparse(td[cls.WEEK_4_TIME_KEY]) < isoparse(cls.FRIDAY_BURST_END):
-                    mapped_dict["rqa_s01e02_raw"] = td[cls.WEEK_4_VALUE_KEY]
+                    mapped_dict["show_id"] = 2
                     mapped_dict["sent_on"] = cls.FRIDAY_CORRECTION_TIME
-                else:
-                    mapped_dict["rqa_s01e04_raw"] = td[cls.WEEK_4_VALUE_KEY]
-                    mapped_dict["sent_on"] = td[cls.WEEK_4_TIME_KEY]
 
-            # Translate all other keys
-            for new_key, old_key in cls.RAPID_PRO_KEY_MAP:
-                if old_key in td:
-                    mapped_dict[new_key] = td[old_key]
+            # Fake the timestamp of redirected week 3 messages to make it look like they arrived on the day
+            # before the incorrect sms ad was sent, i.e. the last day of week 2.
+            # This is super yucky, but works because (a) timestamps are never exported, and (b) this date
+            # is being set to non_logical anyway in channels.py.
+            if cls.WEEK_3_TIME_KEY in td:
+                if message_to_s01e02_dict.get(td["rqa_message"], False):
+                    mapped_dict["sent_on"] = "2018-12-15T00:00:00+03:00"
 
-            if cls.WEEK_3_TIME_KEY in td and message_to_s01e02_dict.get(td[cls.WEEK_3_VALUE_KEY], False):
-                # Fake the timestamp of redirected week 3 messages to make it look like they arrived on the day
-                # before the incorrect sms ad was sent, i.e. the last day of week 2.
-                # This is super yucky, but works because (a) timestamps are never exported, and (b) this date
-                # is being set to non_logical anyway in channels.py.
-                mapped_dict["sent_on"] = "2018-12-15T00:00:00+03:00"
+            td.append_data(mapped_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
-            td.append_data(mapped_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+    @classmethod
+    def remap_key_names(cls, user, data, key_map):
+        for td in data:
+            remapped = dict()
+               
+            for new_key, old_key in key_map:
+                if old_key in td and new_key not in td:
+                    remapped[new_key] = td[old_key]
+
+            td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+    @classmethod
+    def translate_rapid_pro_keys(cls, user, data, coda_input_dir):
+        cls.set_show_ids(user, data, cls.SHOW_ID_MAP)
+        cls.remap_radio_show_weeks(user, data, coda_input_dir)
+        cls.remap_key_names(user, data, cls.RAPID_PRO_KEY_MAP)
+
+        raw_id_map = {
+            1: "rqa_s01e01_raw",
+            2: "rqa_s01e02_raw",
+            3: "rqa_s01e03_raw",
+            4: "rqa_s01e04_raw"
+        }
+
+        for td in data:
+            for show_id, message_key in raw_id_map.items():
+                if "rqa_message" in td and td.get("show_id") == show_id:
+                    td.append_data({message_key: td["rqa_message"]},
+                                   Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
         return data

--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -58,7 +58,7 @@ class TranslateRapidProKeys(object):
 
     WEEK_3_TIME_KEY = "Rqa_S01E03 (Time) - csap_s01e03_activation"
     WEEK_3_VALUE_KEY = "Rqa_S01E03 (Value) - csap_s01e03_activation"
-    WEEK_4_START = isoparse("2018-12-23T00:00:00+03:00")  # TODO: All other dates are strings, this should be too
+    WEEK_4_START = "2018-12-23T00:00:00+03:00"
 
     WEEK_4_TIME_KEY = "Rqa_S01E04 (Time) - csap_s01e04_activation"
     WEEK_4_VALUE_KEY = "Rqa_S01E04 (Value) - csap_s01e04_activation"
@@ -122,7 +122,7 @@ class TranslateRapidProKeys(object):
                 if message_to_s01e02_dict.get(td["rqa_message"], False):
                     mapped_dict["show_id"] = 2
                 # Redirect any week 4 messages which were in the week 3 flow due to a late flow change-over.
-                elif isoparse(td[cls.WEEK_3_TIME_KEY]) > cls.WEEK_4_START:
+                elif isoparse(td[cls.WEEK_3_TIME_KEY]) > isoparse(cls.WEEK_4_START):
                     mapped_dict["show_id"] = 4
 
             # Redirect any week 2 messages which were in the week 4 flow, due to undelivered messages being delivered

--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -119,8 +119,13 @@ class TranslateRapidProKeys(object):
 
             if cls.WEEK_3_TIME_KEY in td:
                 # Redirect any week 3 messages coded as s01e02 in the WS - Correct Dataset scheme to week 2
+                # Also, fake the timestamp of redirected week 3 messages to make it look like they arrived on the day
+                # before the incorrect sms ad was sent, i.e. the last day of week 2.
+                # This is super yucky, but works because (a) timestamps are never exported, and (b) this date
+                # is being set to non_logical anyway in channels.py.
                 if message_to_s01e02_dict.get(td["rqa_message"], False):
                     mapped_dict["show_id"] = 2
+                    mapped_dict["sent_on"] = "2018-12-15T00:00:00+03:00"
                 # Redirect any week 4 messages which were in the week 3 flow due to a late flow change-over.
                 elif isoparse(td[cls.WEEK_3_TIME_KEY]) > isoparse(cls.WEEK_4_START):
                     mapped_dict["show_id"] = 4
@@ -134,14 +139,6 @@ class TranslateRapidProKeys(object):
                 elif isoparse(cls.FRIDAY_BURST_START) <= isoparse(td[cls.WEEK_4_TIME_KEY]) < isoparse(cls.FRIDAY_BURST_END):
                     mapped_dict["show_id"] = 2
                     mapped_dict["sent_on"] = cls.FRIDAY_CORRECTION_TIME
-
-            # Fake the timestamp of redirected week 3 messages to make it look like they arrived on the day
-            # before the incorrect sms ad was sent, i.e. the last day of week 2.
-            # This is super yucky, but works because (a) timestamps are never exported, and (b) this date
-            # is being set to non_logical anyway in channels.py.
-            if cls.WEEK_3_TIME_KEY in td:
-                if message_to_s01e02_dict.get(td["rqa_message"], False):
-                    mapped_dict["sent_on"] = "2018-12-15T00:00:00+03:00"
 
             td.append_data(mapped_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 

--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -126,6 +126,7 @@ class TranslateRapidProKeys(object):
                 if message_to_s01e02_dict.get(td["rqa_message"], False):
                     mapped_dict["show_id"] = 2
                     mapped_dict["sent_on"] = "2018-12-15T00:00:00+03:00"
+
                 # Redirect any week 4 messages which were in the week 3 flow due to a late flow change-over.
                 elif isoparse(td[cls.WEEK_3_TIME_KEY]) > isoparse(cls.WEEK_4_START):
                     mapped_dict["show_id"] = 4


### PR DESCRIPTION
Previously these two tasks were entangled in the same for loop.

Now, there is a for loop for each.

This PR also adds some TODOs to translate_rapid_pro_keys.py, which propose the strategy for more refactorings, to come in future PRs.