### PR TITLE
Configure Binaries from PipelineConfiguration

### DIFF
--- a/project_redss/analysis_file.py
+++ b/project_redss/analysis_file.py
@@ -182,17 +182,11 @@ class AnalysisFile(object):
                     td.append_data({consent_withdrawn_key: Codes.TRUE},
                                    Metadata(user, Metadata.get_call_location(), time.time()))
 
-        # Set consent for the binary questions
-        for td in data:
-            if td["rqa_s01e02_integrate_return_coded"]["CodeID"] == \
-                    CodeSchemes.S01E02_INTEGRATE_RETURN.get_code_with_control_code(Codes.STOP).code_id:
-                td.append_data({consent_withdrawn_key: Codes.TRUE},
-                               Metadata(user, Metadata.get_call_location(), time.time()))
-
-            if td["rqa_s01e03_yes_no_amb_coded"]["CodeID"] == \
-                    CodeSchemes.S01E03_YES_NO_AMB.get_code_with_control_code(Codes.STOP).code_id:
-                td.append_data({consent_withdrawn_key: Codes.TRUE},
-                               Metadata(user, Metadata.get_call_location(), time.time()))
+                if plan.binary_code_scheme is not None:
+                    if td[plan.binary_coded_field]["CodeID"] == \
+                            plan.binary_code_scheme.get_code_with_control_code(Codes.STOP).code_id:
+                        td.append_data({consent_withdrawn_key: Codes.TRUE},
+                                       Metadata(user, Metadata.get_call_location(), time.time()))
 
         # Fold data to have one respondent per row
         to_be_folded = []

--- a/project_redss/analysis_file.py
+++ b/project_redss/analysis_file.py
@@ -125,6 +125,8 @@ class AnalysisFile(object):
         matrix_keys = []
 
         for plan in PipelineConfiguration.RQA_CODING_PLANS:
+            # TODO: If this was a list, codes would come out in the order they're in in the schemes.
+            #       Clarify which is preferable before the next project.
             show_matrix_keys = set()
             for code in plan.code_scheme.codes:
                 show_matrix_keys.add(f"{plan.analysis_file_key}{code.string_value}")
@@ -143,12 +145,7 @@ class AnalysisFile(object):
 
         equal_keys = ["uid", "operator"]
         equal_keys.extend(survey_keys)
-        concat_keys = [
-            "rqa_s01e01_raw",
-            "rqa_s01e02_raw",
-            "rqa_s01e03_raw",
-            "rqa_s01e04_raw"
-        ]
+        concat_keys = [plan.raw_field for plan in PipelineConfiguration.RQA_CODING_PLANS]
         bool_keys = [
             consent_withdrawn_key,
 

--- a/project_redss/analysis_file.py
+++ b/project_redss/analysis_file.py
@@ -125,8 +125,8 @@ class AnalysisFile(object):
         matrix_keys = []
 
         for plan in PipelineConfiguration.RQA_CODING_PLANS:
-            # TODO: If this was a list, codes would come out in the order they're in in the schemes.
-            #       Clarify which is preferable before the next project.
+            # TODO: If this was a list, codes would come out in the order they're in in the schemes, rather than
+            #       needing to be sorted alphabetically. Clarify which is preferable before the next project.
             show_matrix_keys = set()
             for code in plan.code_scheme.codes:
                 show_matrix_keys.add(f"{plan.analysis_file_key}{code.string_value}")
@@ -138,10 +138,9 @@ class AnalysisFile(object):
 
         matrix_keys.sort()
 
-        ambivalent_keys = [
-            "rqa_s01e02_integrate_return",
-            "rqa_s01e03_yes_no"
-        ]
+        ambivalent_keys = [plan.binary_analysis_file_key
+                           for plan in PipelineConfiguration.RQA_CODING_PLANS
+                           if plan.binary_analysis_file_key is not None]
 
         equal_keys = ["uid", "operator"]
         equal_keys.extend(survey_keys)

--- a/project_redss/analysis_file.py
+++ b/project_redss/analysis_file.py
@@ -97,6 +97,7 @@ class AnalysisFile(object):
             if plan.raw_field not in survey_keys:
                 survey_keys.append(plan.raw_field)
 
+        # Convert survey codes to their string values
         for td in data:
             td.append_data(
                 {plan.analysis_file_key: plan.code_scheme.get_code_with_id(td[plan.coded_field]["CodeID"]).string_value
@@ -104,25 +105,23 @@ class AnalysisFile(object):
                 Metadata(user, Metadata.get_call_location(), time.time())
             )
 
-            td.append_data({
-                "rqa_s01e02_integrate_return":
-                    CodeSchemes.S01E02_INTEGRATE_RETURN.get_code_with_id(
-                        td["rqa_s01e02_integrate_return_coded"]["CodeID"]).string_value
-            }, Metadata(user, Metadata.get_call_location(), time.time()))
-
-            td.append_data({
-                "rqa_s01e03_yes_no":
-                    CodeSchemes.S01E03_YES_NO_AMB.get_code_with_id(
-                        td["rqa_s01e03_yes_no_amb_coded"]["CodeID"]).string_value
-            }, Metadata(user, Metadata.get_call_location(), time.time()))
-
+        # Convert the operator code to its string value
         for td in data:
             td.append_data(
                 {"operator": CodeSchemes.OPERATOR.get_code_with_id(td["operator_coded"]["CodeID"]).string_value},
                 Metadata(user, Metadata.get_call_location(), time.time())
             )
 
-        # Translate keys to final values for analysis
+        # Convert RQA binary codes to their string values
+        for td in data:
+            td.append_data(
+                {plan.binary_analysis_file_key:
+                 plan.binary_code_scheme.get_code_with_id(td[plan.binary_coded_field]["CodeID"]).string_value
+                 for plan in PipelineConfiguration.RQA_CODING_PLANS if plan.binary_code_scheme is not None},
+                Metadata(user, Metadata.get_call_location(), time.time())
+            )
+
+        # Translate the RQA reason codes to matrix values
         matrix_keys = []
 
         for plan in PipelineConfiguration.RQA_CODING_PLANS:

--- a/project_redss/apply_manual_codes.py
+++ b/project_redss/apply_manual_codes.py
@@ -49,25 +49,20 @@ class ApplyManualCodes(object):
                 nc_dict = dict()
                 for plan in PipelineConfiguration.RQA_CODING_PLANS:
                     if plan.coded_field not in td:
-                        nc_label = CleaningUtils.make_label_from_cleaner_code(
-                            plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.NOT_CODED),
-                            Metadata.get_call_location()
-                        )
-                        nc_dict[plan.coded_field] = [nc_label.to_dict()]
-                if "rqa_s01e02_coded" not in td:
-                    nc_label = CleaningUtils.make_label_from_cleaner_code(
-                        CodeSchemes.S01E02_INTEGRATE_RETURN,
-                        CodeSchemes.S01E02_INTEGRATE_RETURN.get_code_with_control_code(Codes.NOT_CODED),
-                        Metadata.get_call_location()
-                    )
-                    nc_dict["rqa_s01e02_integrate_return_coded"] = nc_label.to_dict()
-                if "rqa_s01e03_coded" not in td:
-                    nc_label = CleaningUtils.make_label_from_cleaner_code(
-                        CodeSchemes.S01E03_YES_NO_AMB,
-                        CodeSchemes.S01E03_YES_NO_AMB.get_code_with_control_code(Codes.NOT_CODED),
-                        Metadata.get_call_location()
-                    )
-                    nc_dict["rqa_s01e03_yes_no_amb_coded"] = nc_label.to_dict()
+                        if plan.code_scheme is not None:
+                            nc_label = CleaningUtils.make_label_from_cleaner_code(
+                                plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.NOT_CODED),
+                                Metadata.get_call_location()
+                            )
+                            nc_dict[plan.coded_field] = [nc_label.to_dict()]
+
+                        if plan.binary_code_scheme is not None:
+                            nc_label = CleaningUtils.make_label_from_cleaner_code(
+                                plan.binary_code_scheme, plan.binary_code_scheme.get_code_with_control_code(Codes.NOT_CODED),
+                                Metadata.get_call_location()
+                            )
+                            nc_dict[plan.binary_coded_field] = nc_label.to_dict()
+
                 td.append_data(nc_dict, Metadata(user, Metadata.get_call_location(), time.time()))
 
         # Merge manually coded survey files into the cleaned dataset

--- a/project_redss/apply_manual_codes.py
+++ b/project_redss/apply_manual_codes.py
@@ -49,12 +49,11 @@ class ApplyManualCodes(object):
                 nc_dict = dict()
                 for plan in PipelineConfiguration.RQA_CODING_PLANS:
                     if plan.coded_field not in td:
-                        if plan.code_scheme is not None:
-                            nc_label = CleaningUtils.make_label_from_cleaner_code(
-                                plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.NOT_CODED),
-                                Metadata.get_call_location()
-                            )
-                            nc_dict[plan.coded_field] = [nc_label.to_dict()]
+                        nc_label = CleaningUtils.make_label_from_cleaner_code(
+                            plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.NOT_CODED),
+                            Metadata.get_call_location()
+                        )
+                        nc_dict[plan.coded_field] = [nc_label.to_dict()]
 
                         if plan.binary_code_scheme is not None:
                             nc_label = CleaningUtils.make_label_from_cleaner_code(

--- a/project_redss/apply_manual_codes.py
+++ b/project_redss/apply_manual_codes.py
@@ -25,10 +25,10 @@ class ApplyManualCodes(object):
         # Merge manually coded radio show files into the cleaned dataset
         for plan in PipelineConfiguration.RQA_CODING_PLANS:
             rqa_messages = [td for td in data if plan.raw_field in td]
+            coda_input_path = path.join(coda_input_dir, plan.coda_filename)
 
             f = None
             try:
-                coda_input_path = path.join(coda_input_dir, plan.coda_filename)
                 if path.exists(coda_input_path):
                     f = open(coda_input_path, "r")
                 TracedDataCoda2IO.import_coda_2_to_traced_data_iterable_multi_coded(
@@ -37,33 +37,16 @@ class ApplyManualCodes(object):
                 if f is not None:
                     f.close()
 
-        # Apply integrate/return codes for s01e02
-        f = None
-        try:
-            rqa_messages = [td for td in data if "rqa_s01e02_raw" in td]
-            coda_input_path = path.join(coda_input_dir, "s01e02.json")
-            if path.exists(coda_input_path):
-                f = open(coda_input_path, "r")
-            TracedDataCoda2IO.import_coda_2_to_traced_data_iterable(
-                user, rqa_messages, "rqa_s01e02_raw_id",
-                {"rqa_s01e02_integrate_return_coded": CodeSchemes.S01E02_INTEGRATE_RETURN}, f)
-        finally:
-            if f is not None:
-                f.close()
-
-        # Apply yes/no codes for s01e0
-        f = None
-        try:
-            rqa_messages = [td for td in data if "rqa_s01e03_raw" in td]
-            coda_input_path = path.join(coda_input_dir, "s01e03.json")
-            if path.exists(coda_input_path):
-                f = open(coda_input_path, "r")
-            TracedDataCoda2IO.import_coda_2_to_traced_data_iterable(
-                user, rqa_messages, "rqa_s01e03_raw_id",
-                {"rqa_s01e03_yes_no_amb_coded": CodeSchemes.S01E03_YES_NO_AMB}, f)
-        finally:
-            if f is not None:
-                f.close()
+            if plan.binary_code_scheme is not None:
+                f = None
+                try:
+                    if path.exists(coda_input_path):
+                        f = open(coda_input_path, "r")
+                    TracedDataCoda2IO.import_coda_2_to_traced_data_iterable(
+                        user, rqa_messages, plan.id_field, {plan.binary_coded_field: plan.binary_code_scheme}, f)
+                finally:
+                    if f is not None:
+                        f.close()
 
         # Mark data that is noise as Codes.NOT_CODED
         for td in data:

--- a/project_redss/apply_manual_codes.py
+++ b/project_redss/apply_manual_codes.py
@@ -33,20 +33,15 @@ class ApplyManualCodes(object):
                     f = open(coda_input_path, "r")
                 TracedDataCoda2IO.import_coda_2_to_traced_data_iterable_multi_coded(
                     user, rqa_messages, plan.id_field, {plan.coded_field: plan.code_scheme}, f)
+
+                if plan.binary_code_scheme is not None:
+                    if f is not None:
+                        f.seek(0)
+                    TracedDataCoda2IO.import_coda_2_to_traced_data_iterable(
+                        user, rqa_messages, plan.id_field, {plan.binary_coded_field: plan.binary_code_scheme}, f)
             finally:
                 if f is not None:
                     f.close()
-
-            if plan.binary_code_scheme is not None:
-                f = None
-                try:
-                    if path.exists(coda_input_path):
-                        f = open(coda_input_path, "r")
-                    TracedDataCoda2IO.import_coda_2_to_traced_data_iterable(
-                        user, rqa_messages, plan.id_field, {plan.binary_coded_field: plan.binary_code_scheme}, f)
-                finally:
-                    if f is not None:
-                        f.close()
 
         # Mark data that is noise as Codes.NOT_CODED
         for td in data:

--- a/project_redss/auto_code_show_messages.py
+++ b/project_redss/auto_code_show_messages.py
@@ -51,12 +51,11 @@ class AutoCodeShowMessages(object):
             missing_dict = dict()
             for plan in PipelineConfiguration.RQA_CODING_PLANS:
                 if plan.raw_field not in td:
-                    if plan.code_scheme is not None:
-                        na_label = CleaningUtils.make_label_from_cleaner_code(
-                            plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
-                            Metadata.get_call_location()
-                        )
-                        missing_dict[plan.coded_field] = [na_label.to_dict()]
+                    na_label = CleaningUtils.make_label_from_cleaner_code(
+                        plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                        Metadata.get_call_location()
+                    )
+                    missing_dict[plan.coded_field] = [na_label.to_dict()]
 
                     if plan.binary_code_scheme is not None:
                         na_label = CleaningUtils.make_label_from_cleaner_code(

--- a/project_redss/auto_code_show_messages.py
+++ b/project_redss/auto_code_show_messages.py
@@ -64,6 +64,7 @@ class AutoCodeShowMessages(object):
                             Metadata.get_call_location()
                         )
                         missing_dict[plan.binary_coded_field] = na_label.to_dict()
+
             td.append_data(missing_dict, Metadata(user, Metadata.get_call_location(), time.time()))
 
         # Label each message with channel keys

--- a/project_redss/auto_code_show_messages.py
+++ b/project_redss/auto_code_show_messages.py
@@ -58,9 +58,9 @@ class AutoCodeShowMessages(object):
                         )
                         missing_dict[plan.coded_field] = [na_label.to_dict()]
 
-                    if plan.binary_scheme is not None:
+                    if plan.binary_code_scheme is not None:
                         na_label = CleaningUtils.make_label_from_cleaner_code(
-                            plan.binary_scheme, plan.binary_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                            plan.binary_code_scheme, plan.binary_code_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
                             Metadata.get_call_location()
                         )
                         missing_dict[plan.binary_coded_field] = na_label.to_dict()

--- a/project_redss/auto_code_show_messages.py
+++ b/project_redss/auto_code_show_messages.py
@@ -12,7 +12,6 @@ from dateutil.parser import isoparse
 from project_redss.lib import ICRTools, Channels
 from project_redss.lib import MessageFilters
 from project_redss.lib.pipeline_configuration import PipelineConfiguration
-from project_redss.lib.redss_schemes import CodeSchemes
 
 
 class AutoCodeShowMessages(object):
@@ -52,25 +51,19 @@ class AutoCodeShowMessages(object):
             missing_dict = dict()
             for plan in PipelineConfiguration.RQA_CODING_PLANS:
                 if plan.raw_field not in td:
-                    na_label = CleaningUtils.make_label_from_cleaner_code(
-                        plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
-                        Metadata.get_call_location()
-                    )
-                    missing_dict[plan.coded_field] = [na_label.to_dict()]
-            if "rqa_s01e02_raw" not in td:
-                na_label = CleaningUtils.make_label_from_cleaner_code(
-                    CodeSchemes.S01E02_INTEGRATE_RETURN,
-                    CodeSchemes.S01E02_INTEGRATE_RETURN.get_code_with_control_code(Codes.TRUE_MISSING),
-                    Metadata.get_call_location()
-                )
-                missing_dict["rqa_s01e02_integrate_return_coded"] = na_label.to_dict()
-            if "rqa_s01e03_raw" not in td:
-                na_label = CleaningUtils.make_label_from_cleaner_code(
-                    CodeSchemes.S01E03_YES_NO_AMB,
-                    CodeSchemes.S01E03_YES_NO_AMB.get_code_with_control_code(Codes.TRUE_MISSING),
-                    Metadata.get_call_location()
-                )
-                missing_dict["rqa_s01e03_yes_no_amb_coded"] = na_label.to_dict()
+                    if plan.code_scheme is not None:
+                        na_label = CleaningUtils.make_label_from_cleaner_code(
+                            plan.code_scheme, plan.code_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                            Metadata.get_call_location()
+                        )
+                        missing_dict[plan.coded_field] = [na_label.to_dict()]
+
+                    if plan.binary_scheme is not None:
+                        na_label = CleaningUtils.make_label_from_cleaner_code(
+                            plan.binary_scheme, plan.binary_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                            Metadata.get_call_location()
+                        )
+                        missing_dict[plan.binary_coded_field] = na_label.to_dict()
             td.append_data(missing_dict, Metadata(user, Metadata.get_call_location(), time.time()))
 
         # Label each message with channel keys

--- a/project_redss/lib/pipeline_configuration.py
+++ b/project_redss/lib/pipeline_configuration.py
@@ -48,7 +48,10 @@ class PipelineConfiguration(object):
                    run_id_field="rqa_s01e02_run_id",
                    analysis_file_key="rqa_s01e02_",
                    cleaner=None,
-                   code_scheme=CodeSchemes.S01E02_REASONS),
+                   code_scheme=CodeSchemes.S01E02_REASONS,
+                   binary_code_scheme=CodeSchemes.S01E02_INTEGRATE_RETURN,
+                   binary_coded_field="rqa_s01e02_integrate_return_coded",
+                   binary_analysis_file_key="rqa_01_e02_integrate_return"),
 
         CodingPlan(raw_field="rqa_s01e03_raw",
                    coded_field="rqa_s01e03_coded",
@@ -58,7 +61,10 @@ class PipelineConfiguration(object):
                    run_id_field="rqa_s01e03_run_id",
                    analysis_file_key="rqa_s01e03_",
                    cleaner=None,
-                   code_scheme=CodeSchemes.S01E03_REASONS),
+                   code_scheme=CodeSchemes.S01E03_REASONS,
+                   binary_code_scheme=CodeSchemes.S01E03_YES_NO_AMB,
+                   binary_coded_field="rqa_s01e03_yes_no_amb_coded",
+                   binary_analysis_file_key="rqa_01_e03_yes_no"),
 
         CodingPlan(raw_field="rqa_s01e04_raw",
                    coded_field="rqa_s01e04_coded",

--- a/project_redss/lib/pipeline_configuration.py
+++ b/project_redss/lib/pipeline_configuration.py
@@ -17,7 +17,7 @@ class CodingPlan(object):
         self.time_field = time_field
         self.run_id_field = run_id_field
         self.analysis_file_key = analysis_file_key
-        self.binary_scheme = binary_code_scheme
+        self.binary_code_scheme = binary_code_scheme
         self.binary_coded_field = binary_coded_field
         self.binary_analysis_file_key = binary_analysis_file_key
 

--- a/project_redss/lib/pipeline_configuration.py
+++ b/project_redss/lib/pipeline_configuration.py
@@ -51,7 +51,7 @@ class PipelineConfiguration(object):
                    code_scheme=CodeSchemes.S01E02_REASONS,
                    binary_code_scheme=CodeSchemes.S01E02_INTEGRATE_RETURN,
                    binary_coded_field="rqa_s01e02_integrate_return_coded",
-                   binary_analysis_file_key="rqa_01_e02_integrate_return"),
+                   binary_analysis_file_key="rqa_s01e02_integrate_return"),
 
         CodingPlan(raw_field="rqa_s01e03_raw",
                    coded_field="rqa_s01e03_coded",
@@ -64,7 +64,7 @@ class PipelineConfiguration(object):
                    code_scheme=CodeSchemes.S01E03_REASONS,
                    binary_code_scheme=CodeSchemes.S01E03_YES_NO_AMB,
                    binary_coded_field="rqa_s01e03_yes_no_amb_coded",
-                   binary_analysis_file_key="rqa_01_e03_yes_no"),
+                   binary_analysis_file_key="rqa_s01e03_yes_no"),
 
         CodingPlan(raw_field="rqa_s01e04_raw",
                    coded_field="rqa_s01e04_coded",

--- a/project_redss/lib/pipeline_configuration.py
+++ b/project_redss/lib/pipeline_configuration.py
@@ -6,7 +6,8 @@ from project_redss.lib.redss_schemes import CodeSchemes
 
 class CodingPlan(object):
     def __init__(self, raw_field, coded_field, coda_filename, cleaner=None, code_scheme=None, time_field=None,
-                 run_id_field=None, icr_filename=None, analysis_file_key=None, id_field=None):
+                 run_id_field=None, icr_filename=None, analysis_file_key=None, id_field=None,
+                 binary_code_scheme=None, binary_coded_field=None, binary_analysis_file_key=None):
         self.raw_field = raw_field
         self.coded_field = coded_field
         self.coda_filename = coda_filename
@@ -16,6 +17,9 @@ class CodingPlan(object):
         self.time_field = time_field
         self.run_id_field = run_id_field
         self.analysis_file_key = analysis_file_key
+        self.binary_scheme = binary_code_scheme
+        self.binary_coded_field = binary_coded_field
+        self.binary_analysis_file_key = binary_analysis_file_key
 
         if id_field is None:
             id_field = "{}_id".format(self.raw_field)


### PR DESCRIPTION
Replaces the hard-coded binary-handling that was embedded deep within the pipeline with loops that refer to new PipelineConfiguration options.

Note that this still only allows for one reasons scheme and one binary scheme. In future, we will probably want to move to configurations that supported n of each scheme.