### PR TITLE
Remap Function

### DIFF
--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -132,15 +132,14 @@ class TranslateRapidProKeys(object):
             range_end = pytz.utc.localize(datetime.max)
         
         for td in data:
-            if time_key in td:
-                if range_start <= isoparse(td[time_key]) < range_end:
-                    remapped = {
-                        "show_id": show_id_to_remap_to
-                    }
-                    if time_to_adjust_to is not None:
-                        remapped["sent_on"] = time_to_adjust_to
+            if time_key in td and range_start <= isoparse(td[time_key]) < range_end:
+                remapped = {
+                    "show_id": show_id_to_remap_to
+                }
+                if time_to_adjust_to is not None:
+                    remapped["sent_on"] = time_to_adjust_to
 
-                    td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+                td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
     @classmethod
     def remap_radio_shows(cls, user, data, coda_input_dir):

--- a/project_redss/translate_rapid_pro_keys.py
+++ b/project_redss/translate_rapid_pro_keys.py
@@ -126,6 +126,30 @@ class TranslateRapidProKeys(object):
     @classmethod
     def _remap_radio_show_by_time_range(cls, user, data, time_key, show_id_to_remap_to,
                                         range_start=None, range_end=None, time_to_adjust_to=None):
+        """
+        Remaps radio show messages received in the given time range to another radio show.
+        
+        Optionally adjusts the datetime of re-mapped messages to a constant.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to set the show ids of.
+        :type data: iterable of TracedData
+        :param time_key: Key in each TracedData of an ISO 8601-formatted datetime string to read the message sent on
+                         time from.
+        :type time_key: str
+        :param show_id_to_remap_to: Show id to assign to messages received within the given time range.
+        :type show_id_to_remap_to: int
+        :param range_start: Start datetime for the time range to remap radio show messages from, inclusive.
+                            If None, defaults to the beginning of time.
+        :type range_start: datetime | None
+        :param range_end: End datetime for the time range to remap radio show messages from, exclusive.
+                          If None, defaults to the end of time.
+        :type range_end: datetime | None
+        :param time_to_adjust_to: Datetime to assign to the 'sent_on' field of re-mapped shows.
+                                  If None, re-mapped shows will not have timestamps re-adjusted.
+        :type time_to_adjust_to: datetime | None
+        """
         if range_start is None:
             range_start = pytz.utc.localize(datetime.min)
         if range_end is None:
@@ -137,7 +161,7 @@ class TranslateRapidProKeys(object):
                     "show_id": show_id_to_remap_to
                 }
                 if time_to_adjust_to is not None:
-                    remapped["sent_on"] = time_to_adjust_to
+                    remapped[time_key] = time_to_adjust_to.isoformat()
 
                 td.append_data(remapped, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
@@ -185,12 +209,12 @@ class TranslateRapidProKeys(object):
         cls._remap_radio_show_by_time_range(user, data, cls.WEEK_4_TIME_KEY, 2,
                                             range_start=isoparse(cls.THURSDAY_BURST_START),
                                             range_end=isoparse(cls.THURSDAY_BURST_END),
-                                            time_to_adjust_to=cls.THURSDAY_CORRECTION_TIME)
+                                            time_to_adjust_to=isoparse(cls.THURSDAY_CORRECTION_TIME))
 
         cls._remap_radio_show_by_time_range(user, data, cls.WEEK_4_TIME_KEY, 2,
                                             range_start=isoparse(cls.FRIDAY_BURST_START),
                                             range_end=isoparse(cls.FRIDAY_BURST_END),
-                                            time_to_adjust_to=cls.FRIDAY_CORRECTION_TIME)
+                                            time_to_adjust_to=isoparse(cls.FRIDAY_CORRECTION_TIME))
 
     @classmethod
     def remap_key_names(cls, user, data, key_map):


### PR DESCRIPTION
Move time-range remapping to a reusable function _remap_radio_show_by_time_range.

This covers 2 of the 3 cases where we needed to remap in ReDSS. The third remapped based on WS labels, so I think we should leave this one as-is until and implement properly when we implement the rest of the WS remapping.